### PR TITLE
Draft: Support for checking protocol versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ cython_debug/
 *.exe
 *.out
 *.app
+/test_*
+/.vscode/c_cpp_properties.json

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
@@ -24,7 +25,7 @@ void DaikinS21Climate::setup() {
 
 void DaikinS21Climate::dump_config() {
   ESP_LOGCONFIG(TAG, "DaikinS21Climate:");
-  ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+  ESP_LOGCONFIG(TAG, "  Update interval: %" PRIu32, this->get_update_interval());
   if (this->room_sensor_ != nullptr) {
     if (!this->room_sensor_unit_is_valid()) {
       ESP_LOGCONFIG(TAG, "  ROOM SENSOR: INVALID UNIT '%s' (must be °C or °F)",
@@ -139,6 +140,8 @@ void DaikinS21Climate::save_setpoint(float value) {
       case DaikinClimateMode::Heat:
         this->save_setpoint(value, this->heat_setpoint_pref);
         break;
+      default:
+        break;
     }
   }
 }
@@ -162,6 +165,8 @@ optional<float> DaikinS21Climate::load_setpoint(DaikinClimateMode mode) {
       break;
     case DaikinClimateMode::Heat:
       loaded = this->load_setpoint(this->heat_setpoint_pref);
+      break;
+    default:
       break;
   }
   return loaded;

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -153,7 +153,7 @@ optional<float> DaikinS21Climate::load_setpoint(ESPPreferenceObject &pref) {
 
 optional<float> DaikinS21Climate::load_setpoint(DaikinClimateMode mode) {
   optional<float> loaded;
-  switch (this->s21->get_climate_mode()) {
+  switch (mode) {
     case DaikinClimateMode::Auto:
       loaded = this->load_setpoint(this->auto_setpoint_pref);
       break;

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -125,7 +125,7 @@ void DaikinS21Climate::save_setpoint(float value, ESPPreferenceObject &pref) {
 }
 
 void DaikinS21Climate::save_setpoint(float value) {
-  auto mode = this->s21->get_climate_mode();
+  auto mode = this->e2d_climate_mode(this->mode);
   optional<float> prev = this->load_setpoint(mode);
   // Only save if value is diff from what's already saved.
   if (abs(value - prev.value_or(0.0)) >= SETPOINT_STEP) {

--- a/components/daikin_s21/climate/daikin_s21_climate.cpp
+++ b/components/daikin_s21/climate/daikin_s21_climate.cpp
@@ -333,7 +333,7 @@ void DaikinS21Climate::update() {
       // the target temperature here if it appears uninitialized.
       float current_s21_sp = this->s21->get_setpoint();
       float unexpected_diff = abs(this->expected_s21_setpoint - current_s21_sp);
-      if (this->target_temperature == 0.0) {
+      if (this->target_temperature == 0.0 || isnanf(this->target_temperature)) {
         // Use stored setpoint for mode, or fall back to use s21's setpoint.
         auto stored = this->load_setpoint(this->s21->get_climate_mode());
         this->target_temperature = stored.value_or(current_s21_sp);

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -932,6 +932,16 @@ void DaikinS21::update() {
 #endif
 }
 
+void DaikinS21::full_update() {
+  ESP_LOGI(TAG, "Performing full required update");
+  if(!this->run_queries(this->required_queries)) { // run all required queries
+    ESP_LOGW(TAG, "Full update failed");
+  }
+  if (this->debug_protocol) {
+    this->dump_state();
+  }
+}
+
 void DaikinS21::dump_state() {
   ESP_LOGD(TAG, "** BEGIN STATE *****************************");
 
@@ -974,7 +984,7 @@ void DaikinS21::set_daikin_climate_settings(bool power_on,
   if (!this->send_cmd({'D', '1'}, cmd)) {
     ESP_LOGW(TAG, "Failed basic climate CMD");
   } else {
-    this->update();
+    this->full_update();
   }
 }
 
@@ -987,7 +997,7 @@ void DaikinS21::set_swing_settings(bool swing_v, bool swing_h) {
   if (!this->send_cmd({'D', '5'}, cmd)) {
     ESP_LOGW(TAG, "Failed swing CMD");
   } else {
-    this->update();
+    this->full_update();
   }
 }
 
@@ -999,7 +1009,7 @@ void DaikinS21::set_powerful_settings(bool value)
   if (!this->send_cmd({'D', '6'}, cmd)) {
     ESP_LOGW(TAG, "Failed powerful CMD");
   } else {
-    this->update();
+    this->full_update();
   }
 }
 
@@ -1011,7 +1021,7 @@ void DaikinS21::set_econo_settings(bool value)
   if (!this->send_cmd({'D', '7'}, cmd)) {
     ESP_LOGW(TAG, "Failed econo CMD");
   } else {
-    this->update();
+    this->full_update();
   }
 }
 

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1243,7 +1243,8 @@ void DaikinS21::update() {
 
 void DaikinS21::full_update() {
   ESP_LOGI(TAG, "Performing full required update");
-  if(!this->run_queries(this->state_queries) || !this->run_queries(this->basic_queries)) { 
+  delay(500); // delay to allow the device to process the previous command
+  if(!this->run_queries(this->basic_queries) || !this->run_queries(this->state_queries)) { 
     // run all required queries
     ESP_LOGW(TAG, "Full update failed");
   }

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -10,7 +10,7 @@ namespace daikin_s21 {
 #define ACK 6
 #define NAK 21
 
-#define S21_RESPONSE_TIMEOUT 500
+#define S21_RESPONSE_TIMEOUT 250
 
 static const char *const TAG = "daikin_s21";
 
@@ -328,16 +328,16 @@ bool DaikinS21::parse_response(std::vector<uint8_t> rcode,
       this->setpoint = ((payload[2] - 28) * 5);  // Celsius * 10
       this->fan = (DaikinFanMode) payload[3];
       return true;
-    } else if(uint8_starts_with_str(rcode, StateResponse::Swing)) {
+    } else if(uint8_starts_with_str(rcode, StateResponse::SwingOrHumidity)) {
       // F5 -> G5 -- Swing state
       this->swing_v = payload[0] & 1;
       this->swing_h = payload[0] & 2;
       return true;
-    } else if(uint8_starts_with_str(rcode, StateResponse::Powerful)) {
+    } else if(uint8_starts_with_str(rcode, StateResponse::SpecialModes)) {
       // F6 -> G6 - "powerful" mode
       this->powerful = (payload[0] == '2') ? 1 : 0;
       return true;
-    } else if(uint8_starts_with_str(rcode, StateResponse::Econo)) {
+    } else if(uint8_starts_with_str(rcode, StateResponse::DemandAndEcono)) {
       // F7 -> G7 - "eco" mode
       this->econo = (payload[1] == '2') ? 1 : 0;
       return true;
@@ -379,6 +379,10 @@ bool DaikinS21::parse_response(std::vector<uint8_t> rcode,
         this->fy00_protocol_major = 3;
         this->fy00_protocol_minor = 2;
         this->protocol_checked = true;
+      } else if(uint8_starts_with_str(payload, NewProtocol::Protocol3_40)) {
+        this->fy00_protocol_major = 3;
+        this->fy00_protocol_minor = 4;
+        this->protocol_checked = true;
       } else {
         return false;
       }
@@ -388,17 +392,77 @@ bool DaikinS21::parse_response(std::vector<uint8_t> rcode,
       this->temp_inside = temp_f9_byte_to_c10(&payload[0]);
       this->temp_outside = temp_f9_byte_to_c10(&payload[1]);
       return true;
-    } 
+    } else if(uint8_starts_with_str(rcode, StateResponse::OptionalFeatures)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::OnOffTimer)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::ErrorStatus)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::ModelCode)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::IRCounter)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::V2OptionalFeatures)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::PowerConsumption)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::LouvreAngle)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::V3OptionalFeatures)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::AllowedTemperatureRange)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::ModelName)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::ProductionInformation)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::ProductionOrder)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::IndoorProductionInformation)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, StateResponse::OutdoorProductionInformation)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    }
   } else if(uint8_starts_with_str(rcode, "S")) {
-    if(uint8_starts_with_str(rcode, EnvironmentResponse::Inside)) {
+    if(uint8_starts_with_str(rcode, EnvironmentResponse::InsideTemperature)) {
       // RH -> SH - inside temperature
       this->temp_inside = temp_bytes_to_c10(payload);
       return true;
-    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::Coil)) {
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::LiquidTemperature)) {
       // RI -> SI - coil temperature
       this->temp_coil = temp_bytes_to_c10(payload);
       return true;
-    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::Outside)) {
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::OutsideTemperature)) {
       // Ra -> Sa - outside temperature
       this->temp_outside = temp_bytes_to_c10(payload);
       return true;
@@ -406,10 +470,70 @@ bool DaikinS21::parse_response(std::vector<uint8_t> rcode,
       // RL -> SL - fan speed
       this->fan_rpm = bytes_to_num(payload) * 10;
       return true;
-    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::Compressor)) {
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::CompressorFrequency)) {
       // Rd -> Sd - compressor state / frequency? Idle if 0.
       this->idle =
       (payload[0] == '0' && payload[1] == '0' && payload[2] == '0');
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::PowerOnOff)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::IndoorUnitMode)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::TemperatureSetPoint)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::OnTimerSetting)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::OffTimerSetting)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::FanMode)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::FanSetPoint)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::LouvreAngleSetPoint)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::VerticalSwingAngle)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::TargetTemperature)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::IndoorFrequencyCommandSignal)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::IndoorHumidity)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::CompressorOnOff)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::UnitState)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
+      return true;
+    } else if(uint8_starts_with_str(rcode, EnvironmentResponse::SystemState)) {
+      ESP_LOGW(TAG, "S21 unhandled: %s -> %s (%d)", str_repr(rcode).c_str(),
+             str_repr(payload).c_str(), payload.size());
       return true;
     } else {
       // default
@@ -431,39 +555,308 @@ bool DaikinS21::run_queries(std::vector<std::string> queries) {
   bool success = true;
 
   for (auto q : queries) {
-    std::vector<uint8_t> code(q.begin(), q.end());
-    success = this->s21_query(code) && success;
+    success = this->run_query(q) && success;
   }
 
   return success;  // True if all queries successful
 }
 
-std::vector<std::string> queries = {StateQuery::Basic, StateQuery::Swing, EnvironmentQuery::Compressor};
+bool DaikinS21::run_query(std::string query) {
+  std::vector<uint8_t> code(query.begin(), query.end());
+  if(query == "FY00" && this->f8_protocol != -1){
+    this->s21_query(code);
+    return true; // special case where FY00 can return NAK
+  }
+  return this->s21_query(code);
+}
+
+/**
+ * Runs the next startup query command
+ * @return true if all the startup queries have been run successfully
+ */
+bool DaikinS21::run_next_startup_query() {
+  if (startup_queries.size() == 0) {
+    ESP_LOGD(TAG, "Startup query size is 0");
+    return false; // special case if queries are empty
+  }
+  if (startup_query_index < startup_queries.size()) {
+    ESP_LOGD(TAG, "Running startup query: %s", startup_queries[this->startup_query_index].c_str());
+    if(this->run_query(startup_queries[this->startup_query_index])) {
+      startup_query_index++; // increment once this query is successful
+    }
+  } else {
+    startup_complete = true; // if all queries are done, set startup_complete to true
+  }
+
+  return startup_complete;  // true if all queries successful else false
+}
+
+/**
+ * Runs the next required query command
+ * @return true if query was run successfully
+ */
+bool DaikinS21::run_next_required_query() {
+  if (required_queries.size() == 0) {
+    ESP_LOGD(TAG, "Required query size is 0");
+    return false; // special case if queries are empty
+  }
+  if (required_query_index >= required_queries.size()){
+    required_query_index = 0; // reset the index to 0
+  }
+  ESP_LOGD(TAG, "Running required query: %s", required_queries[this->required_query_index].c_str());
+  bool success = this->run_query(required_queries[this->required_query_index]);
+  if (success) {
+    required_query_index++; // increment once this query is successful
+  }
+  return success;
+}
+
+/**
+ * Runs the next optional query command
+ * @return true if query was run successfully
+ */
+bool DaikinS21::run_next_optional_query() {
+  if (optional_queries.size() == 0) {
+    ESP_LOGD(TAG, "Optional query size is 0");
+    return false; // special case if queries are empty
+  }
+  if (optional_query_index >= optional_queries.size()){
+    optional_query_index = 0; // reset the index to 0
+  }
+  ESP_LOGD(TAG, "Running optional query: %s", optional_queries[this->optional_query_index].c_str());
+  bool success = this->run_query(optional_queries[this->optional_query_index]);
+  if (success) {
+    optional_query_index++; // increment once this query is successful
+  }
+  return success;
+}
+
+void DaikinS21::set_queries() {
+  ESP_LOGD(TAG, "Setting queries with protocol %s", this->get_protocol_version());
+  this->startup_queries = this->get_startup_queries();
+  this->required_queries = this->get_required_update_queries();
+  this->optional_queries = this->get_optional_update_queries();
+}
+
+// Protocol 0
+//  Supported R commands: RA, RB, RC, RD, RE, RF, RG, RH, RI, RK, RL, RM, RN, RW, RX, Ra, Rb, Rd, Re, Rg, Rz
+//  Supported F commands: F1, F2, F3, F4, F5, F8
+//  Supported miscellaneous commands: A, M, V
+//  BRP069B41 startup sequence: F2 F1 F3 F4 F5 F8 RH Ra M
+//  BRP069B41 polling loop: F2 F1 F3 F4 F5 F8 [sensor]
+// Protocol 2
+//  Supported R commands: RA, RB, RC, RD, RE, RF, RG, RH, RI, RK, RL, RM, RN, RW, RX, Ra, Rb, Rd, Re, Rg, Rz
+//  Supported miscellaneous commands: A, M, V, VS000M
+//  BRP068B41 startup sequence: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FC FY00 M DJ2010
+//  BRP068B41 polling loop: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT [sensor]
+// Protocol 3.0
+//  BRP069B41 startup sequence: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FC FY00 FY10 FY20 M DJ2030 DJ2010
+//  BRP069B41 polling loop: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT [sensor]
+// Protocol 3.1
+//  BRP069B41 startup sequence: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FC FY00 FY10 FY20 M VS000M DJ4030
+//  BRP069B41 polling loop: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT [sensor]
+// Protocol 3.2
+//  BRP069B41 startup sequence: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FC FY00 FY10 FY20 FU00 FU02 VS000M DJ5010 D70000
+//  BRP069B41 polling loop: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FU02 FU04 [sensor]
+//  BRP069C41 startup sequence: F2 F1 F3 F4 F5 F8 F9 F6 F7 FB FG FK FM FN FP FQ FS FT FC FY00 FY10 FY20 FU00 FU02 VS000M Rd RL RH RN RI Ra RX FX00 FX10 FX20 FX30 FX40 FX50 FX60 FX70 FX80 Rz52 Rz72 FX90 FXA0 FXB0 FXC0 DY10 DY20
+
+// Below commands, queried by BRP069B41 controller are listed in their order. 
+// This gives a good overview of which commands are actually known by the controller and officially used by Daikin. 
+// [sensor] denotes one R family command out of sensor query sequence (TBD). 
+// I. e. the controller asks one particular each poll iteration. 
+// On next iteration next sensor will be queried.
+
+// TODO set up start up queries and then polling loop queries
+
+const char* DaikinS21::get_protocol_version() {
+  if (!this->protocol_checked)
+  {
+    return HumanReadableProtocol::ProtocolUnknown;
+  }
+  switch (f8_protocol)
+  {
+    case 0:
+      return HumanReadableProtocol::Protocol0;
+    case 2: 
+      switch (fy00_protocol_minor)
+      {
+      case 0:
+        return HumanReadableProtocol::Protocol3_0;
+      case 1:
+        return HumanReadableProtocol::Protocol3_1;
+      case 2:
+        return HumanReadableProtocol::Protocol3_2;
+      case 4:
+        return HumanReadableProtocol::Protocol3_4;
+      default:
+        return HumanReadableProtocol::Protocol2;
+      }
+    default:
+      return HumanReadableProtocol::ProtocolUnknown;
+  }
+}
+
+std::vector<std::string> DaikinS21::get_startup_queries(){
+  const char* protocol = this->get_protocol_version();
+  if (protocol == HumanReadableProtocol::ProtocolUnknown) {
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else if (protocol == HumanReadableProtocol::Protocol0) 
+  {
+    //  BRP069B41 startup sequence: F2 F1 F3 F4 F5 F8 
+    // RH Ra M
+    return {
+      StateQuery::OldProtocol, 
+      StateQuery::NewProtocol,
+      StateQuery::OptionalFeatures, // F2
+      StateQuery::Basic, // F1
+      StateQuery::OnOffTimer, // F3
+      StateQuery::ErrorStatus, // F4
+      StateQuery::SwingOrHumidity, //F5
+      EnvironmentQuery::InsideTemperature, // RH
+      EnvironmentQuery::OutsideTemperature // Ra
+    };
+  } else if (protocol == HumanReadableProtocol::Protocol2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else if (protocol == HumanReadableProtocol::Protocol3_0) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else if (protocol == HumanReadableProtocol::Protocol3_1) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else if (protocol == HumanReadableProtocol::Protocol3_2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else if (protocol == HumanReadableProtocol::Protocol3_4) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  } else {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  }
+}
+
+std::vector<std::string> DaikinS21::get_required_update_queries(){
+  const char* protocol = this->get_protocol_version();
+  if (protocol == HumanReadableProtocol::ProtocolUnknown) {
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol0) {
+    //  BRP069B41 polling loop: F2 F1 F3 F4 F5 F8 [sensor]
+    // RA, RB, RC, RD, RE, RF, RG, RH, RI, RK, RL, RM, RN, RW, RX, Ra, Rb, Rd, Re, Rg, Rz
+    return {
+      StateQuery::OptionalFeatures, // F2
+      StateQuery::Basic, // F1
+      StateQuery::OnOffTimer, // F3
+      StateQuery::ErrorStatus, // F4
+      StateQuery::SwingOrHumidity, //F5
+      EnvironmentQuery::CompressorFrequency // Rd
+    };
+  } else if (protocol == HumanReadableProtocol::Protocol2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_0) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_1) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_4) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  }
+}
+
 // These queries might fail but they won't affect the basic functionality
 // F6, F7 and F9 should only be run for protocols that support it (after F8 and FY00)
-std::vector<std::string> failable_queries = {EnvironmentQuery::Inside, EnvironmentQuery::Coil, EnvironmentQuery::Outside, EnvironmentQuery::FanSpeed};
-// TODO set up queries for different protocol versions
+// std::vector<std::string> failable_queries = {EnvironmentQuery::InsideTemperature, EnvironmentQuery::LiquidTemperature, EnvironmentQuery::OutsideTemperature, EnvironmentQuery::FanSpeed};
+std::vector<std::string> DaikinS21::get_optional_update_queries(){
+  const char* protocol = this->get_protocol_version();
+  if (protocol == HumanReadableProtocol::ProtocolUnknown) {
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol0) {
+    return {
+      EnvironmentQuery::InsideTemperature, 
+      EnvironmentQuery::LiquidTemperature, 
+      EnvironmentQuery::OutsideTemperature, 
+      EnvironmentQuery::FanSpeed
+    };
+  } else if (protocol == HumanReadableProtocol::Protocol2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_0) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_1) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_2) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else if (protocol == HumanReadableProtocol::Protocol3_4) {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  } else {
+    ESP_LOGE(TAG, "Protocol %s is not supported yet", protocol);
+    this->mark_failed();
+    return {};
+  }
+}
 
 void DaikinS21::update() {
   // if protocol has not been set then we run the protocol queries
   if(!this->protocol_checked || this->f8_protocol == 2 && this->fy00_protocol_major == -1) {
-    // protocol_checked is set when:
+    // protocol_checked is set true when:
     // - F8 returns 0
     // - F8 returns one of the 2 version 2 variants and FY00 returns 3
     // - FY00 returns protocol 3.2
     // - FY00 returns protocol 3.0/3.1 and F8 is already one of the version 2 variants
     // special case is when f8 version is 2 and fy00 is NAK, then we need to just assume protocol version 2
-    this->run_queries({StateQuery::OldProtocol, StateQuery::NewProtocol});
-  }
-  if (this->run_queries(queries)) {
-    this->run_queries(failable_queries);
-    if(!this->ready) {
-      ESP_LOGI(TAG, "Daikin S21 Ready");
-      this->ready = true;
+    this->run_next_startup_query();
+    if (this->protocol_checked){ // when it first gets set to true
+      this->set_queries(); // set the three sets of queries
     }
-  }
-  if (this->debug_protocol) {
-    this->dump_state();
+  } else {
+    if(!this->startup_complete) {
+      // startup queries can run at once and block
+      this->startup_complete = this->run_next_startup_query();
+      ESP_LOGI(TAG, "Daikin S21 startup complete: %s", YESNO(this->startup_complete));
+    } else {
+      // required updates should run one per loop
+      if (this->run_next_required_query()) {
+        // optional updates should run one per loop and only if the required update succeeded
+        this->run_next_optional_query();
+        if(!this->ready) {
+          ESP_LOGI(TAG, "Daikin S21 Ready");
+          this->ready = true;
+        }
+      }
+      if (this->debug_protocol) {
+        this->dump_state();
+      }
+    }
   }
 
 #ifdef S21_EXPERIMENTS
@@ -499,8 +892,8 @@ void DaikinS21::dump_state() {
            c10_f(this->temp_outside));
   ESP_LOGD(TAG, "   Coil: %.1f C (%.1f F)", c10_c(this->temp_coil),
            c10_f(this->temp_coil));
-  ESP_LOGD(TAG, "    Protocol: x (F8: %d, FY00: %.1f)",
-           this->f8_protocol, this->fy00_protocol);
+  ESP_LOGD(TAG, "    Protocol: %s (F8: %d [variant: %d], FY00: [major: %d, minor: %d])",
+           this->get_protocol_version(), this->f8_protocol, this->f8_protocol_variant, this->fy00_protocol_major, this->fy00_protocol_minor);
 
   ESP_LOGD(TAG, "** END STATE *****************************");
 }

--- a/components/daikin_s21/s21.cpp
+++ b/components/daikin_s21/s21.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "s21.h"
 
 using namespace esphome;
@@ -105,7 +106,7 @@ void DaikinS21::check_uart_settings() {
       ESP_LOGE(
           TAG,
           "  Invalid baud_rate: Integration requested baud_rate %u but you "
-          "have %u!",
+          "have %" PRIu32 "!",
           S21_BAUD_RATE, uart->get_baud_rate());
     }
     if (uart->get_stop_bits() != S21_STOP_BITS) {
@@ -133,7 +134,7 @@ void DaikinS21::check_uart_settings() {
 
 void DaikinS21::dump_config() {
   ESP_LOGCONFIG(TAG, "DaikinS21:");
-  ESP_LOGCONFIG(TAG, "  Update interval: %u", this->get_update_interval());
+  ESP_LOGCONFIG(TAG, "  Update interval: %" PRIu32, this->get_update_interval());
   this->check_uart_settings();
 }
 

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -289,10 +289,12 @@ class DaikinS21 : public PollingComponent {
   const char* get_protocol_version();
   std::vector<std::string> get_startup_queries();
   bool run_next_startup_query();
-  std::vector<std::string> get_required_update_queries();
-  bool run_next_required_query();
-  std::vector<std::string> get_optional_update_queries();
-  bool run_next_optional_query();
+  std::vector<std::string> get_state_queries();
+  bool run_next_state_query();
+  std::vector<std::string> get_environment_queries();
+  bool run_next_environment_query();
+  std::vector<std::string> get_basic_queries();
+  bool run_next_basic_query();
   void set_queries();
 
   uart::UARTComponent *tx_uart{nullptr};
@@ -322,10 +324,12 @@ class DaikinS21 : public PollingComponent {
   uint8_t fy00_protocol_minor = -1;
   std::vector<std::string> startup_queries = {StateQuery::OldProtocol, StateQuery::NewProtocol};
   uint8_t startup_query_index = 0;
-  std::vector<std::string> required_queries = {};
-  uint8_t required_query_index = 0;
-  std::vector<std::string> optional_queries = {};
-  uint8_t optional_query_index = 0;
+  std::vector<std::string> state_queries = {};
+  uint8_t state_query_index = 0;
+  std::vector<std::string> environment_queries = {};
+  uint8_t environment_query_index = 0;
+  std::vector<std::string> basic_queries = {};
+  uint8_t basic_query_index = 0;
   bool little_endian = false;
 };
 

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -246,6 +246,7 @@ inline float c10_f(int16_t c10) { return c10_c(c10) * 1.8 + 32.0; }
 class DaikinS21 : public PollingComponent {
  public:
   void update() override;
+  void full_update();
   void dump_config() override;
   void set_uarts(uart::UARTComponent *tx, uart::UARTComponent *rx);
   void set_debug_protocol(bool set) { this->debug_protocol = set; }

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -28,38 +28,191 @@ enum class DaikinFanMode : uint8_t {
 
 namespace StateQuery {
   inline constexpr const char* Basic = "F1";
-  inline constexpr const char* Swing = "F5";
-  inline constexpr const char* Powerful = "F6";
-  inline constexpr const char* Econo = "F7";
+  inline constexpr const char* OptionalFeatures = "F2";
+  inline constexpr const char* OnOffTimer = "F3";
+  inline constexpr const char* ErrorStatus = "F4";
+  inline constexpr const char* SwingOrHumidity = "F5";
+  inline constexpr const char* SpecialModes = "F6";
+  inline constexpr const char* DemandAndEcono = "F7";
   inline constexpr const char* OldProtocol = "F8";
-  inline constexpr const char* NewProtocol = "FY00";
   inline constexpr const char* InsideOutsideTemperatures = "F9";
+  // FA
+  // FB
+  inline constexpr const char* ModelCode = "FC";
+  inline constexpr const char* IRCounter = "FG";
+  inline constexpr const char* V2OptionalFeatures = "FK";
+  // FL
+  inline constexpr const char* PowerConsumption = "FM";
+  // FN 
+  // FP
+  // FQ
+  inline constexpr const char* LouvreAngle = "FR";
+  // FS
+  // FT
+  inline constexpr const char* V3OptionalFeatures = "FU00";
+  inline constexpr const char* AllowedTemperatureRange = "FU02";
+  // FU04
+  inline constexpr const char* ModelName = "FU05";
+  inline constexpr const char* ProductionInformation = "FU15";
+  inline constexpr const char* ProductionOrder = "FU25";
+  inline constexpr const char* IndoorProductionInformation = "FU35";
+  inline constexpr const char* OutdoorProductionInformation = "FU45";
+  // FV
+  // FX00
+  // FX10
+  // FX20
+  // FX30
+  // FX40
+  // FX50
+  // FX60
+  // FX70
+  // FX80
+  // FX90
+  // FXA0
+  // FXB0
+  // FXC0
+  // FXD0
+  // FXE0
+  // FXF0
+  // FX01
+  // FX11
+  // FX21
+  // FX31
+  // FX41
+  // FX51
+  // FX61
+  // FX71
+  // FX81
+  inline constexpr const char* NewProtocol = "FY00";
+  // FY10
+  // FY20
 }  // namespace StateQuery
 
 namespace EnvironmentQuery {
-  inline constexpr const char* Inside = "RH";
-  inline constexpr const char* Coil = "RI";
-  inline constexpr const char* Outside = "Ra";
+  inline constexpr const char* PowerOnOff = "RA";
+  inline constexpr const char* IndoorUnitMode = "RB";
+  inline constexpr const char* TemperatureSetPoint = "RC";
+  inline constexpr const char* OnTimerSetting = "RD";
+  inline constexpr const char* OffTimerSetting = "RE";
+  // RF
+  inline constexpr const char* FanMode = "RG";
+  inline constexpr const char* InsideTemperature = "RH";
+  inline constexpr const char* LiquidTemperature = "RI";
+  inline constexpr const char* FanSetPoint = "RK";
   inline constexpr const char* FanSpeed = "RL";
-  inline constexpr const char* Compressor = "Rd";
+  inline constexpr const char* LouvreAngleSetPoint = "RM";
+  inline constexpr const char* VerticalSwingAngle = "RN";
+  // RW
+  inline constexpr const char* TargetTemperature = "RX"; // (not set point, see details)
+  inline constexpr const char* OutsideTemperature = "Ra";
+  inline constexpr const char* IndoorFrequencyCommandSignal = "Rb";
+  inline constexpr const char* CompressorFrequency = "Rd";
+  inline constexpr const char* IndoorHumidity = "Re";
+  inline constexpr const char* CompressorOnOff = "Rg";
+  inline constexpr const char* UnitState = "RzB2";
+  inline constexpr const char* SystemState = "RzC3";
+  // Rz52
+  // Rz72
 } // namespace EnvironmentQuery
 
+namespace StateCommand {
+  inline constexpr const char* PowerModeTempFan = "D1";
+  // D2
+  inline constexpr const char* OnOffTimer = "D3";
+  inline constexpr const char* LouvreSwing = "D5";
+  inline constexpr const char* Powerful = "D6";
+  inline constexpr const char* Econo = "D7";
+  // DH
+  // DJ
+  // DR
+}
+
 namespace StateResponse {
-  inline constexpr const char* Basic = "G1";
-  inline constexpr const char* Swing = "G5";
-  inline constexpr const char* Powerful = "G6";
-  inline constexpr const char* Econo = "G7";
-  inline constexpr const char* OldProtocol = "G8";
-  inline constexpr const char* NewProtocol = "GY00";
-  inline constexpr const char* InsideOutsideTemperatures = "G9";
+  inline constexpr const char* Basic = "G1"; //
+  inline constexpr const char* OptionalFeatures = "G2";
+  inline constexpr const char* OnOffTimer = "G3";
+  inline constexpr const char* ErrorStatus = "G4";
+  inline constexpr const char* SwingOrHumidity = "G5"; //
+  inline constexpr const char* SpecialModes = "G6"; //
+  inline constexpr const char* DemandAndEcono = "G7"; //
+  inline constexpr const char* OldProtocol = "G8"; //
+  inline constexpr const char* InsideOutsideTemperatures = "G9"; //
+  // GA
+  // GB
+  inline constexpr const char* ModelCode = "GC";
+  inline constexpr const char* IRCounter = "GG";
+  inline constexpr const char* V2OptionalFeatures = "GK";
+  // GL
+  inline constexpr const char* PowerConsumption = "GM";
+  // GN
+  // GP
+  // GQ
+  inline constexpr const char* LouvreAngle = "GR";
+  // GS
+  // GT
+  inline constexpr const char* V3OptionalFeatures = "GU00";
+  inline constexpr const char* AllowedTemperatureRange = "GU02";
+  // GU04
+  inline constexpr const char* ModelName = "GU05";
+  inline constexpr const char* ProductionInformation = "GU15";
+  inline constexpr const char* ProductionOrder = "GU25";
+  inline constexpr const char* IndoorProductionInformation = "GU35";
+  inline constexpr const char* OutdoorProductionInformation = "GU45";
+  // GV
+  // GX00
+	// GX10
+	// GX20
+	// GX30
+	// GX40
+	// GX50
+	// GX60
+	// GX70
+	// GX80
+	// GX90
+	// GXA0
+	// GXB0
+	// GXC0
+	// GXD0
+	// GXE0
+	// GXF0
+	// GX01
+	// GX11
+	// GX21
+	// GX31
+	// GX41
+	// GX51
+	// GX61
+	// GX71
+	// GX81
+  inline constexpr const char* NewProtocol = "GY00"; //
+  // GY10
+  // GY20
 }  // namespace StateResponse
 
 namespace EnvironmentResponse {
-  inline constexpr const char* Inside = "SH";
-  inline constexpr const char* Coil = "SI";
-  inline constexpr const char* Outside = "Sa";
+  inline constexpr const char* PowerOnOff = "SA";
+  inline constexpr const char* IndoorUnitMode = "SB";
+  inline constexpr const char* TemperatureSetPoint = "SC";
+  inline constexpr const char* OnTimerSetting = "SD";
+  inline constexpr const char* OffTimerSetting = "SE";
+  inline constexpr const char* FanMode = "SG";
+  inline constexpr const char* InsideTemperature = "SH";
+  inline constexpr const char* LiquidTemperature = "SI";
+  inline constexpr const char* FanSetPoint = "SK";
   inline constexpr const char* FanSpeed = "SL";
-  inline constexpr const char* Compressor = "Sd";
+  inline constexpr const char* LouvreAngleSetPoint = "SM";
+  inline constexpr const char* VerticalSwingAngle = "SN";
+  // SW
+  inline constexpr const char* TargetTemperature = "SX"; // (not set point, see details)
+  inline constexpr const char* OutsideTemperature = "Sa";
+  inline constexpr const char* IndoorFrequencyCommandSignal = "Sb";
+  inline constexpr const char* CompressorFrequency = "Sd";
+  inline constexpr const char* IndoorHumidity = "Se";
+  inline constexpr const char* CompressorOnOff = "Sg";
+  inline constexpr const char* UnitState = "SzB2";
+  inline constexpr const char* SystemState = "SzC3";
+  // Sz52
+  // Sz72
 } // namespace EnvironmentResponse
 
 namespace OldProtocol {
@@ -71,7 +224,18 @@ namespace OldProtocol {
 namespace NewProtocol {
   inline constexpr const char* Protocol3_00_or_3_10 = "0030";
   inline constexpr const char* Protocol3_20 = "0230";
+  inline constexpr const char* Protocol3_40 = "0430";
 }  // namespace NewProtocol
+
+namespace HumanReadableProtocol {
+  inline constexpr const char* ProtocolUnknown = "unknown";
+  inline constexpr const char* Protocol0 = "0";
+  inline constexpr const char* Protocol2 = "2";
+  inline constexpr const char* Protocol3_0 = "3.0";
+  inline constexpr const char* Protocol3_1 = "3.1";
+  inline constexpr const char* Protocol3_2 = "3.2";
+  inline constexpr const char* Protocol3_4 = "3.4";
+} // namespace HumanReadableProtocol
 
 std::string daikin_climate_mode_to_string(DaikinClimateMode mode);
 std::string daikin_fan_mode_to_string(DaikinFanMode mode);
@@ -117,9 +281,18 @@ class DaikinS21 : public PollingComponent {
   bool s21_query(std::vector<uint8_t> code);
   bool parse_response(std::vector<uint8_t> rcode, std::vector<uint8_t> payload);
   bool run_queries(std::vector<std::string> queries);
+  bool run_query(std::string query);
   void dump_state();
   void check_uart_settings();
   bool wait_byte_available(uint32_t  timeout);
+  const char* get_protocol_version();
+  std::vector<std::string> get_startup_queries();
+  bool run_next_startup_query();
+  std::vector<std::string> get_required_update_queries();
+  bool run_next_required_query();
+  std::vector<std::string> get_optional_update_queries();
+  bool run_next_optional_query();
+  void set_queries();
 
   uart::UARTComponent *tx_uart{nullptr};
   uart::UARTComponent *rx_uart{nullptr};
@@ -141,10 +314,17 @@ class DaikinS21 : public PollingComponent {
   bool idle = true;
   bool has_presets = true;
   bool protocol_checked = false;
+  bool startup_complete = false;
   uint8_t f8_protocol = -1;
   uint8_t f8_protocol_variant = -1;
   uint8_t fy00_protocol_major = -1;
   uint8_t fy00_protocol_minor = -1;
+  std::vector<std::string> startup_queries = {StateQuery::OldProtocol, StateQuery::NewProtocol};
+  uint8_t startup_query_index = 0;
+  std::vector<std::string> required_queries = {};
+  uint8_t required_query_index = 0;
+  std::vector<std::string> optional_queries = {};
+  uint8_t optional_query_index = 0;
 };
 
 class DaikinS21Client {

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -325,6 +325,7 @@ class DaikinS21 : public PollingComponent {
   uint8_t required_query_index = 0;
   std::vector<std::string> optional_queries = {};
   uint8_t optional_query_index = 0;
+  bool little_endian = false;
 };
 
 class DaikinS21Client {

--- a/components/daikin_s21/s21.h
+++ b/components/daikin_s21/s21.h
@@ -2,6 +2,7 @@
 
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
+#include "utils.h"
 
 namespace esphome {
 namespace daikin_s21 {
@@ -24,6 +25,53 @@ enum class DaikinFanMode : uint8_t {
   Speed4 = '6',
   Speed5 = '7',
 };
+
+namespace StateQuery {
+  inline constexpr const char* Basic = "F1";
+  inline constexpr const char* Swing = "F5";
+  inline constexpr const char* Powerful = "F6";
+  inline constexpr const char* Econo = "F7";
+  inline constexpr const char* OldProtocol = "F8";
+  inline constexpr const char* NewProtocol = "FY00";
+  inline constexpr const char* InsideOutsideTemperatures = "F9";
+}  // namespace StateQuery
+
+namespace EnvironmentQuery {
+  inline constexpr const char* Inside = "RH";
+  inline constexpr const char* Coil = "RI";
+  inline constexpr const char* Outside = "Ra";
+  inline constexpr const char* FanSpeed = "RL";
+  inline constexpr const char* Compressor = "Rd";
+} // namespace EnvironmentQuery
+
+namespace StateResponse {
+  inline constexpr const char* Basic = "G1";
+  inline constexpr const char* Swing = "G5";
+  inline constexpr const char* Powerful = "G6";
+  inline constexpr const char* Econo = "G7";
+  inline constexpr const char* OldProtocol = "G8";
+  inline constexpr const char* NewProtocol = "GY00";
+  inline constexpr const char* InsideOutsideTemperatures = "G9";
+}  // namespace StateResponse
+
+namespace EnvironmentResponse {
+  inline constexpr const char* Inside = "SH";
+  inline constexpr const char* Coil = "SI";
+  inline constexpr const char* Outside = "Sa";
+  inline constexpr const char* FanSpeed = "SL";
+  inline constexpr const char* Compressor = "Sd";
+} // namespace EnvironmentResponse
+
+namespace OldProtocol {
+  inline constexpr const char* Protocol0 = "\x30\x00\x00\x00";
+  inline constexpr const char* Protocol2_1 = "\x30\x32\x00\x00";
+  inline constexpr const char* Protocol2_2 = "\x30\x32\x30\x30";
+}  // namespace OldProtocol
+
+namespace NewProtocol {
+  inline constexpr const char* Protocol3_00_or_3_10 = "0030";
+  inline constexpr const char* Protocol3_20 = "0230";
+}  // namespace NewProtocol
 
 std::string daikin_climate_mode_to_string(DaikinClimateMode mode);
 std::string daikin_fan_mode_to_string(DaikinFanMode mode);
@@ -92,8 +140,11 @@ class DaikinS21 : public PollingComponent {
   uint16_t fan_rpm = 0;
   bool idle = true;
   bool has_presets = true;
+  bool protocol_checked = false;
   uint8_t f8_protocol = -1;
-  float fy00_protocol = -1.0;
+  uint8_t f8_protocol_variant = -1;
+  uint8_t fy00_protocol_major = -1;
+  uint8_t fy00_protocol_minor = -1;
 };
 
 class DaikinS21Client {

--- a/components/daikin_s21/sensor/__init__.py
+++ b/components/daikin_s21/sensor/__init__.py
@@ -8,8 +8,10 @@ from esphome.components import sensor
 from esphome.const import (
     CONF_ID,
     UNIT_CELSIUS,
+    UNIT_REVOLUTIONS_PER_MINUTE,
     ICON_THERMOMETER,
-    DEVICE_CLASS_SPEED,
+    ICON_FAN,
+    DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
 )
@@ -57,16 +59,16 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_FAN_SPEED): sensor.sensor_schema(
-                unit_of_measurement="rpm",
-                icon="mdi:fan",
+                unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+                icon=ICON_FAN,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_SPEED,
+                device_class=DEVICE_CLASS_EMPTY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
         }
     )
     .extend(S21_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("10s"))
+    .extend(cv.polling_component_schema("5s"))
 )
 
 

--- a/components/daikin_s21/utils.cpp
+++ b/components/daikin_s21/utils.cpp
@@ -1,5 +1,4 @@
 #include "utils.h"
-#include <string.h>
 
 bool uint8_starts_with_str(const std::vector<uint8_t>& vec, const char* str) {
     if (vec.size() < strlen(str)) {
@@ -17,3 +16,103 @@ bool uint8_starts_with_str(const std::vector<uint8_t>& vec, const char* str) {
     
     return true;
   }
+
+bool is_little_endian() {
+    union {
+      uint32_t i;
+      uint8_t c[4];
+    } test = {0x01020304};
+    
+    // If we're little-endian, the least significant byte (0x04) will be at the lowest address
+    // If we're big-endian, the most significant byte (0x01) will be at the lowest address
+    return test.c[0] == 0x04;
+}
+
+// Adapated from ESPHome UART debugger
+std::string hex_repr(uint8_t *bytes, size_t len) {
+  std::string res;
+  char buf[5];
+  for (size_t i = 0; i < len; i++) {
+    if (i > 0)
+      res += ':';
+    sprintf(buf, "%02X", bytes[i]);
+    res += buf;
+  }
+  return res;
+}
+
+std::string hex_repr(std::vector<uint8_t> &bytes) {
+  return hex_repr(&bytes[0], bytes.size());
+}
+
+std::string bin_repr(uint8_t *bytes, size_t len, bool little_endian) {
+  std::string res;
+  char buf[9]; // 8 bits + null terminator
+  for (size_t i = 0; i < len; i++) {
+    if (i > 0)
+      res += ' ';
+    if (little_endian) {
+      // Little-endian: LSB (bit 0) first
+      for (int j = 0; j <= 7; j++) {
+        buf[j] = ((bytes[i] & (1 << j)) ? '1' : '0');
+      }
+    } else {
+      // Big-endian: MSB (bit 7) first (default)
+      for (int j = 7; j >= 0; j--) {
+        buf[7-j] = ((bytes[i] & (1 << j)) ? '1' : '0');
+      }
+    }
+    buf[8] = '\0';
+    res += buf;
+  }
+  return res;
+}
+
+std::string bin_repr(std::vector<uint8_t> &bytes, bool little_endian) {
+  return bin_repr(&bytes[0], bytes.size(), little_endian);
+}
+
+std::string bin_repr(std::vector<uint8_t> &bytes) {
+  return bin_repr(&bytes[0], bytes.size(), true) + " defaulted to little-endian";
+}
+
+// Adapated from ESPHome UART debugger
+std::string str_repr(uint8_t *bytes, size_t len) {
+  std::string res;
+  char buf[5];
+  for (size_t i = 0; i < len; i++) {
+    if (bytes[i] == 7) {
+      res += "\\a";
+    } else if (bytes[i] == 8) {
+      res += "\\b";
+    } else if (bytes[i] == 9) {
+      res += "\\t";
+    } else if (bytes[i] == 10) {
+      res += "\\n";
+    } else if (bytes[i] == 11) {
+      res += "\\v";
+    } else if (bytes[i] == 12) {
+      res += "\\f";
+    } else if (bytes[i] == 13) {
+      res += "\\r";
+    } else if (bytes[i] == 27) {
+      res += "\\e";
+    } else if (bytes[i] == 34) {
+      res += "\\\"";
+    } else if (bytes[i] == 39) {
+      res += "\\'";
+    } else if (bytes[i] == 92) {
+      res += "\\\\";
+    } else if (bytes[i] < 32 || bytes[i] > 127) {
+      sprintf(buf, "\\x%02X", bytes[i]);
+      res += buf;
+    } else {
+      res += bytes[i];
+    }
+  }
+  return res;
+}
+
+std::string str_repr(std::vector<uint8_t> &bytes) {
+  return str_repr(&bytes[0], bytes.size());
+}

--- a/components/daikin_s21/utils.cpp
+++ b/components/daikin_s21/utils.cpp
@@ -1,0 +1,19 @@
+#include "utils.h"
+#include <string.h>
+
+bool uint8_starts_with_str(const std::vector<uint8_t>& vec, const char* str) {
+    if (vec.size() < strlen(str)) {
+        return false;
+    }
+  
+    for (size_t i = 0; i < strlen(str); i++)
+    {
+      if(vec[i] == static_cast<uint8_t>(str[i])) {
+        continue;
+      } else {
+        return false;
+      }
+    }
+    
+    return true;
+  }

--- a/components/daikin_s21/utils.h
+++ b/components/daikin_s21/utils.h
@@ -2,5 +2,15 @@
 
 #include <vector>
 #include <cstdint>
+#include <string.h>
+#include <string>
 
 bool uint8_starts_with_str(const std::vector<uint8_t>& vec, const char* str);
+bool is_little_endian();
+std::string hex_repr(uint8_t *bytes, size_t len);
+std::string hex_repr(std::vector<uint8_t> &bytes);
+std::string bin_repr(uint8_t *bytes, size_t len, bool little_endian);
+std::string bin_repr(std::vector<uint8_t> &bytes, bool little_endian);
+std::string bin_repr(std::vector<uint8_t> &bytes);
+std::string str_repr(uint8_t *bytes, size_t len);
+std::string str_repr(std::vector<uint8_t> &bytes);

--- a/components/daikin_s21/utils.h
+++ b/components/daikin_s21/utils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+bool uint8_starts_with_str(const std::vector<uint8_t>& vec, const char* str);

--- a/components/test/test_utils.cpp
+++ b/components/test/test_utils.cpp
@@ -1,0 +1,26 @@
+//// filepath: test/test_utils.cpp
+#include <gtest/gtest.h>
+#include "utils.h"
+
+// A simple test for the uint8_starts_with_str helper.
+TEST(S21Test, Uint8StrcompMatches) {
+  std::vector<uint8_t> vec = {'F', '1', 'X'};
+  const char* str = "F1";
+  EXPECT_TRUE(uint8_starts_with_str(vec, str));
+
+  vec = {'F', '1', 'X', 'Y'};
+  str = "F1XY";
+  EXPECT_TRUE(uint8_starts_with_str(vec, str));
+
+  vec = {'F', '1', 'X', 'Y'};
+  str = "G1XY";
+  EXPECT_FALSE(uint8_starts_with_str(vec, str));
+
+  vec = {'F', 'Y', '0', '0'};
+  str = "FY0";
+  EXPECT_TRUE(uint8_starts_with_str(vec, str));
+
+  vec = {'G', '8', '0', '0'};
+  str = "G8";
+  EXPECT_TRUE(uint8_starts_with_str(vec, str));
+}


### PR DESCRIPTION
This relates to #1 but should theoretically make the component work for any model by checking protocol versions and running only the commands that the specific model's protocol should support.